### PR TITLE
Hotfix/trivy ignore

### DIFF
--- a/scripts/trivy_scan.sh
+++ b/scripts/trivy_scan.sh
@@ -35,8 +35,28 @@ fi
 echo "Printing trivy ignore file" 
 cd "$GITHUB_WORKSPACE" && cat .trivyignore
 
-echo "Checking for low level vulnerablities" 
-eval "trivy --exit-code 0 --severity=HIGH,MEDIUM,LOW,UNKNOWN $IMAGE"
+echo "Listing all vulnerablities."
+eval "trivy image --exit-code 0 $IMAGE" 
 
-echo "Checking for critical risk vulnerablities"
-eval "trivy --exit-code 1 --severity CRITICAL $IMAGE"
+echo "Checking for critical risk vulnerablities. Ignoring unfixed."
+set +e
+eval "trivy image --ignore-unfixed --exit-code 1 --severity CRITICAL $IMAGE"
+
+e=$?
+if [ "$e" -eq "0" ]; then
+    echo "________________________________________________________________"
+    echo "No critical issues found."
+    echo "________________________________________________________________"
+elif [ "$e" -gt "0" ]; then
+    set -e
+    echo -e "\e[1;31m ________________________________________________________________\e[0m"
+    echo -e "\e[1;31m ________________________________________________________________\e[0m"
+    echo ""
+    echo ""
+    echo -e "\e[1;31m Critical issues found in Dockerfile. Please fix them to proceed.\e[0m"
+    echo ""
+    echo ""
+    echo -e "\e[1;31m ________________________________________________________________\e[0m"
+    echo -e "\e[1;31m ________________________________________________________________\e[0m"
+    exit 1 
+fi


### PR DESCRIPTION
# Description

Ignoring unfixed CVEs in Trivy scan



## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Tested by pointing actions-python to this branch, and lazy-api to branch of actions-python.

```yaml
- Test case: New unfixed CVEs are ignored
   Steps: |
     Running this (workflow)[https://github.com/variant-inc/lazy-api/runs/4940650268?check_suite_focus=true] show the following 
CVEs found by Ralph are ignored -CVE-2022-23218, CVE-2022-23219. New CVEs were previously not ignored 
      in this (workflow)[https://github.com/variant-inc/lazy-api/runs/4924915554?check_suite_focus=true].
You can also see message shows when no vulnerabilities with fixes are found.
```
- [x] Sanity Testing

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added documentation to test
