### PR TITLE
[CLOUD-1741] removed -x

### DIFF
--- a/scripts/ecr_create.sh
+++ b/scripts/ecr_create.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -ex
+set -e
 
 ECR_REPO=$1
 URL_ECR_REPO=$( echo "$ECR_REPO" | sed 's/\//\%2F/g')

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -26,7 +26,7 @@ DOCKERFILE_PATH="$INPUT_DOCKERFILE_DIR_PATH"
 mkdir -p /publish
 
 touch args.txts
-env | tee args.txt
+env > args.txt
 BUILD_ARGS=""
 while IFS='=' read -r n v; do BUILD_ARGS+="--build-arg $n='$v' "; done < <(cat args.txt)
 

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -xe
+set -e
 
 AWS_ACCOUNT_ID=$(aws sts get-caller-identity --output text --query Account)
 ECR_REGISTRY="$AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com"


### PR DESCRIPTION
# Description

Removes echoing of docker parameters to logs and removes aws ecr creds from being echoed to logs.

Fixes [CLOUD-1741](https://drivevariant.atlassian.net/browse/CLOUD-1741)

I will retag `v1` after the PR has been approved.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

[Testing Branch and repo](https://github.com/variant-inc/dx-demo-dotnet-api/tree/f/CLOUD-1741)

Test Case 1 [control (current behavior)]:
- Steps
  - set  the `uses` for `actions-dotnet` to be `v1`:  `uses: variant-inc/actions-dotnet@v1` in https://github.com/variant-inc/dx-demo-dotnet-api/blob/f/CLOUD-1741/.github/workflows/octo-push.yaml
  - commit and push
  - review the `CI` > `Run variant-inc/actions-dotnet@v1` step
- Results
  - There will be docker parameters and aws ecr creds logged, including:
    - [docker login](https://github.com/variant-inc/dx-demo-dotnet-api/runs/6926223494?check_suite_focus=true#step:5:966)
    - [aws ecr creds](https://github.com/variant-inc/dx-demo-dotnet-api/runs/6926223494?check_suite_focus=true#step:5:976)
    - [docker build](https://github.com/variant-inc/dx-demo-dotnet-api/runs/6926223494?check_suite_focus=true#step:5:1624)
    - [docker image rm](https://github.com/variant-inc/dx-demo-dotnet-api/runs/6926223494?check_suite_focus=true#step:5:1993)
 
Test Case 2 [apply the fix: actions-dotnet test]:
- Steps
  - set  the `uses` for `actions-dotnet` to be `f/CLOUD-1741`:  `uses: variant-inc/actions-dotnet@f/CLOUD-1741` in https://github.com/variant-inc/dx-demo-dotnet-api/blob/f/CLOUD-1741/.github/workflows/octo-push.yaml
- Results
  - The docker parameters and aws ecr creds are no longer logged
  - [example](https://github.com/variant-inc/dx-demo-dotnet-api/runs/6986163928?check_suite_focus=true)
  - testing hint: search for `docker` in the log

Test Case 3 [apply the fix: actions-python test]:
- Steps
  - Review the log for https://github.com/variant-inc/dx-demo-cron/runs/6986278764?check_suite_focus=true
- Results
  -  The docker parameters and aws ecr creds are no longer logged

Test Case 4 [apply the fix: actions-nodejs test]:
- Steps
  - Review the control log: https://github.com/variant-inc/demo-nodejs-app/runs/6937711629?check_suite_focus=true
  - Review the fixed log: https://github.com/variant-inc/demo-nodejs-app/runs/6986710750?check_suite_focus=true
- Results
  - The fixed log will no longer contain docker parameters or aws ecr creds

Test Case 5 [apply the fix: actions-cpp test]:
- Steps
  - Review the control log: https://github.com/variant-inc/prime/runs/6939346578?check_suite_focus=true
  - Review the fixed log: https://github.com/variant-inc/prime/runs/6986840597?check_suite_focus=true
- Results
  - The fixed log will no longer contain docker parameters or aws ecr creds

- [x] Sanity Testing

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added documentation to test
