### PR TITLE
[hotfix] trivy scan 

### DIFF
--- a/scripts/publish.ps1
+++ b/scripts/publish.ps1
@@ -64,7 +64,7 @@ try {
         ce docker push "$Image"
         Write-Output "End: Docker Push"
     } else {
-        Write-Output "Skipping Docker Push because of critical errors in trivy scan!"
+        Write-Error "Skipping Docker Push because of critical errors in trivy scan!"
     }
 }
 catch {

--- a/scripts/publish.ps1
+++ b/scripts/publish.ps1
@@ -57,7 +57,7 @@ try {
 
     Write-Output "Start: Trivy Scan"
     sh -c "./actions-collection/scripts/trivy_scan.sh"
-    Write-Output "End: Trivy Scan, exitcode: $LASTEXITCODE"
+    Write-Output "End: Trivy Scan"
 
     if ($LASTEXITCODE -eq 0){
         Write-Output "Start: Docker Push"

--- a/scripts/publish.ps1
+++ b/scripts/publish.ps1
@@ -57,7 +57,7 @@ try {
 
     Write-Output "Start: Trivy Scan"
     sh -c "./actions-collection/scripts/trivy_scan.sh"
-    Write-Output "End: Trivy Scan"
+    Write-Output "End: Trivy Scan, exitcode: $LASTEXITCODE"
 
     if ($LASTEXITCODE -eq 0){
         Write-Output "Start: Docker Push"

--- a/scripts/publish.ps1
+++ b/scripts/publish.ps1
@@ -56,16 +56,10 @@ try {
     Invoke-Expression $expression
 
     Write-Output "Start: Trivy Scan"
-    sh -c "./actions-collection/scripts/trivy_scan.sh"
+    ce sh -c "./actions-collection/scripts/trivy_scan.sh"
     Write-Output "End: Trivy Scan"
 
-    if ($LASTEXITCODE -eq 0){
-        Write-Output "Start: Docker Push"
-        ce docker push "$Image"
-        Write-Output "End: Docker Push"
-    } else {
-        Write-Error "Skipping Docker Push because of critical errors in trivy scan!"
-    }
+    ce docker push "$Image"
 }
 catch {
     Write-Output "`e[31m----------------------------------------------------------------`e[0m";

--- a/scripts/publish.ps1
+++ b/scripts/publish.ps1
@@ -59,7 +59,13 @@ try {
     sh -c "./actions-collection/scripts/trivy_scan.sh"
     Write-Output "End: Trivy Scan"
 
-    ce docker push "$Image"
+    if ($LASTEXITCODE -eq 0){
+        Write-Output "Start: Docker Push"
+        ce docker push "$Image"
+        Write-Output "End: Docker Push"
+    } else {
+        Write-Output "Skipping Docker Push because of critical errors in trivy scan!"
+    }
 }
 catch {
     Write-Output "`e[31m----------------------------------------------------------------`e[0m";


### PR DESCRIPTION
# Description

Hotfix for bug which continued with docker build and push even if trivy scan failed.

https://drivevariant.atlassian.net/browse/CLOUD-1856

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
repo - https://github.com/variant-inc/trivy-test-luka

prerequisites:
app repo:
actions-python ref updated: https://github.com/variant-inc/trivy-test-luka/blob/master/.github/workflows/build.yaml#L33
actions-python repo:
actions-python tag updated: https://github.com/variant-inc/actions-python/blob/h/cloud-1856-trivy-scan/action.yml#L24
actions-python ref updated: https://github.com/variant-inc/actions-python/blob/h/cloud-1856-trivy-scan/entrypoint.sh#L20


1. test case - critical CVE added in .trivyignore
- Make commit to app repo
- verify GH action does docker build and push, [test run](https://github.com/variant-inc/trivy-test-luka/runs/7148257465?check_suite_focus=true#step:6:522)
2. test case - critical CVE present
- remove .trivyignore from [S3](https://s3.console.aws.amazon.com/s3/buckets/trivy-ops?region=us-west-2&prefix=variant-inc/trivy-test-luka/&showversions=false)
- re-run the action, [test run](https://github.com/variant-inc/trivy-test-luka/runs/7148161995?check_suite_focus=true#step:6:541)
- NOTE: still shows success due to other bug [CLOUD-1860](https://drivevariant.atlassian.net/browse/CLOUD-1860)

- [x] Sanity Testing

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added documentation to test
