### PR TITLE
[CLOUD-1862] changed AWS_REGION to AWS_DEFAULT_REGION

### DIFF
--- a/scripts/ecr_create.sh
+++ b/scripts/ecr_create.sh
@@ -7,7 +7,7 @@ URL_ECR_REPO=$( echo "$ECR_REPO" | sed 's/\//\%2F/g')
 echo "ECR_REPO: $ECR_REPO"
 echo "URL_ECR_REPO: $URL_ECR_REPO"
 
-curl -f -L "url"  --request GET "https://$LAZY_API_URL/tenants/apps/profiles/production/regions/$AWS_REGION/ecr/repo/$URL_ECR_REPO/repo-policy" \
+curl -f -L "url"  --request GET "https://$LAZY_API_URL/tenants/apps/profiles/production/regions/$AWS_DEFAULT_REGION/ecr/repo/$URL_ECR_REPO/repo-policy" \
   --header "x-api-key:  $LAZY_API_KEY" \
 || { echo "Repo not found. Hence creating a new repo with name ${ECR_REPO}" &&
   wget \
@@ -19,12 +19,11 @@ curl -f -L "url"  --request GET "https://$LAZY_API_URL/tenants/apps/profiles/pro
   --header 'Content-Type: application/json' \
   --body-data "{
         \"profile\" : \"production\",
-        \"region\": \"$AWS_REGION\",
+        \"region\": \"$AWS_DEFAULT_REGION\",
         \"options\": {
             \"repositoryName\": \"$ECR_REPO\",
             \"imageTagMutability\": \"MUTABLE\"
-            
         }
     }" \
-  "https://$LAZY_API_URL/tenants/apps/profiles/production/regions/$AWS_REGION/ecr/repo" 
+  "https://$LAZY_API_URL/tenants/apps/profiles/production/regions/$AWS_DEFAULT_REGION/ecr/repo"
   }


### PR DESCRIPTION
# Description

Fixes [CLOUD-1862](https://drivevariant.atlassian.net/browse/CLOUD-1862)

actions-collection ecr_create.sh and publish.ps1 use different aws region vars. Need to normalize.

I will repoint the v1 tag after the PR has been approved.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

[test branch](https://github.com/variant-inc/demo-python-flask-variant-api/tree/tuan/test)

Test Case 1 [AWS_REGION & AWS_DEFAULT_REGION set to us-east-1]:
- Steps
  - set `actions-python` to be `uses: variant-inc/actions-python@f/cloud-1862`
  - set AWS_DEFAULT_REGION and AWS_DEFAULT_REGION to us-east-1
  ```
  env:
    AWS_DEFAULT_REGION: us-east-2
    AWS_REGION: us-east-2
  ```
  - commit and push
- Result
 - build should complete. Image should be in the variant-prod account ECR, region us-east-1
 - https://github.com/variant-inc/demo-python-flask-variant-api/actions/runs/2598788413
 - https://octopus.apps.ops-drivevariant.com/app#/Spaces-2/projects/demo-api/deployments/releases/test-0.241.1

Test Case 2 [AWS_REGION unset & AWS_DEFAULT_REGION=us-east-2]:
- Steps
  - set `actions-python` to be `uses: variant-inc/actions-python@f/cloud-1862`
  - set AWS_DEFAULT_REGION to us-east-2
  ```
  env:
    AWS_DEFAULT_REGION: us-east-2
  ```
  - commit and push
- Result
 - build should complete. Image should be in the variant-prod account ECR, region us-east-2
 - https://github.com/variant-inc/demo-python-flask-variant-api/actions/runs/2598858662
 - https://octopus.apps.ops-drivevariant.com/app#/Spaces-2/projects/demo-api/releases/test-0.242.1

  Test Case 3 [AWS_REGION & AWS_DEFAULT_REGION unset]:
- Steps
  - set `actions-python` to be `uses: variant-inc/actions-python@f/cloud-1862`
  - remove environment variable references in the workflow for AWS_DEFAULT_REGION and AWS_DEFAULT_REGION
  - commit and push
- Result
 - build should complete. Image should be in the variant-prod account ECR, region us-east-1
 - https://github.com/variant-inc/demo-python-flask-variant-api/actions/runs/2598945036
 - https://octopus.apps.ops-drivevariant.com/app#/Spaces-2/projects/demo-api/releases/test-0.243.1

- [x] Sanity Testing

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added documentation to test
