### PR TITLE
[CLOUD-1860] write-error when publish fails

### DIFF
--- a/scripts/publish.ps1
+++ b/scripts/publish.ps1
@@ -62,11 +62,17 @@ try {
     ce docker push "$Image"
 }
 catch {
-    Write-Output "`e[31m----------------------------------------------------------------`e[0m";
-    Write-Output "`e[31m Error occured in build and publishing image`e[0m";
-    Write-Output "`e[31m----------------------------------------------------------------`e[0m";
+    $local_error_message = @("`e[31m----------------------------------------------------------------`e[0m"
+                            ,"`e[31m Error occurred in build and publishing image`e[0m"
+                            ,"`e[31m----------------------------------------------------------------`e[0m"
+    );
+    Write-Output "`e[31m Error occurred in build and publishing image`e[0m"
 }
 finally {
+    if ($local_error_message)
+    {
+        Write-Error "`r`n$($local_error_message -join "`r`n")"
+    }
     ce docker logout "$EcrRegistry"
     if ($true -eq $removeImage) {
         Write-Output "Removing image"

--- a/scripts/publish.ps1
+++ b/scripts/publish.ps1
@@ -62,17 +62,15 @@ try {
     ce docker push "$Image"
 }
 catch {
-    $local_error_message = @("`e[31m----------------------------------------------------------------`e[0m"
-                            ,"`e[31m Error occurred in build and publishing image`e[0m"
-                            ,"`e[31m----------------------------------------------------------------`e[0m"
-    );
-    Write-Output "`e[31m Error occurred in build and publishing image`e[0m"
+    $local_error_message = @"
+`e[31m----------------------------------------------------------------`e[0m
+`e[31m Error occurred in build and publishing image`e[0m
+`e[31m----------------------------------------------------------------`e[0m
+"@
+    Write-Error "$local_error_message"
 }
 finally {
-    if ($local_error_message)
-    {
-        Write-Error "`r`n$($local_error_message -join "`r`n")"
-    }
+
     ce docker logout "$EcrRegistry"
     if ($true -eq $removeImage) {
         Write-Output "Removing image"


### PR DESCRIPTION
# Description

Ensure workflow fails when build/publish fails

Fixes [CLOUD-1860](https://drivevariant.atlassian.net/browse/CLOUD-1860)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

[Test branch](https://github.com/variant-inc/demo-python-flask-variant-api/tree/tuan/test)
**Actions-Python branch** f/cloud-1860

Test Case 1 [Baseline test]:
- Steps
  - point octo-push.yaml to the actions-python branch
  - set the AWS_DEFAULT_REGION and AWS_REGION environment vars in octo-push.yaml to `us-east-1`
  - commit and push
- Result
 - Github shows all green
 - Github log shows no failure
 - image is pushed to ECR in us-east-1
 - https://github.com/variant-inc/demo-python-flask-variant-api/actions/runs/2617105102

Test Case 2 [Test missing AWS_REGION]:
- *NOTE:* This test case now succeeds because of [PR for actions-setup CLOUD-1854](https://github.com/variant-inc/actions-setup/pull/10)
- Steps
  - point octo-push.yaml to the actions-python branch
  - set the AWS_DEFAULT_REGION environment var in octo-push.yaml to `us-east-1` leave AWS_REGION unset
  - commit and push
- Result
 - Github show failure
 - Github log shows failure
 -  no image is pushed to ECR
 - https://github.com/variant-inc/demo-python-flask-variant-api/actions/runs/2617143732

Test Case 3 [Test AWS_REGION != AWS_DEFAULT_REGION]:
- Steps
  - point octo-push.yaml to the actions-python branch
  - set the AWS_DEFAULT_REGION environment var in octo-push.yaml to `us-east-1` set AWS_REGION to `us-east-2`
  - commit and push
- Result
 - Github show failure
 - Github log shows failure
 -  no image is pushed to ECR
 - https://github.com/variant-inc/demo-python-flask-variant-api/actions/runs/2617339267
 - https://github.com/variant-inc/demo-python-flask-variant-api/runs/7216235470?check_suite_focus=true

Test Case 4 [Test AWS_REGION unset and AWS_DEFAULT_REGION=us-east2]:
- Steps
  - point octo-push.yaml to the actions-python branch
  - set the AWS_DEFAULT_REGION environment var in octo-push.yaml to `us-east-2` and un set AWS_REGION
  - commit and push
- Result
 - Github show failure
 - Github log shows failure
 -  no image is pushed to ECR
 - https://github.com/variant-inc/demo-python-flask-variant-api/actions/runs/2623313417

- [x] Sanity Testing

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added documentation to test
