### PR TITLE
[hotfix] added check around retrieval of commit info for new repos

### DIFF
--- a/scripts/skip_sonar_run.ps1
+++ b/scripts/skip_sonar_run.ps1
@@ -30,11 +30,13 @@ function CheckSonarRun {
     }
     $Response = Invoke-RestMethod -Uri $sonarCheckUrl `
         -Headers $headers -Method GET
-    $CommitSha = $Response.branches | Where-Object {
-        $_.name -in @($env:GITHUB_REF_NAME)
-    }  | Select-Object -First 1 -ExpandProperty commit
+    $Project = $Response.branches | Where-Object { $_.name -in $env:GITHUB_REF_NAME }
 
-    return ($env:GITHUB_SHA -eq $CommitSha.sha)
+    if ($Project.commit.length -eq 0) {
+        Write-Output "No commit found for $SONAR_PROJECT_KEY in branch $env:GITHUB_REF_NAME"
+        return false
+    }
+    return ($env:GITHUB_SHA -eq $Project.commit.sha)
 }
 
 if (![string]::IsNullOrEmpty($SONAR_PROJECT_KEY_INPUT)) {


### PR DESCRIPTION
# Description

Hotfix for the `skip_sonar_run.ps1` throwing an exception for the master/main branch which does not yet have a commit that was successfully scanned. Presented in the chat below:
https://drivevariant.slack.com/archives/CQD742SSG/p1657739503787419

The script attempts to expand a null object which throws an exception in PowerShell.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

URL used in the browser to retrieve SonarCloud project info:
https://sonarcloud.io/api/project_branches/list?project=variant-inc_dx-demo-cron

![image](https://user-images.githubusercontent.com/19310023/178839393-ce08624b-e4de-4ba2-ae39-aa18f27d75c8.png)

![image](https://user-images.githubusercontent.com/19310023/178840881-a5397da9-1ed4-48c7-bfd6-6724ee71efec.png)


[Test repo](https://github.com/variant-inc/dx-demo-cron)
[Actions-python branch](https://github.com/variant-inc/actions-python/tree/f/hotfix-skip-sonar)

[I created this repo for safe testing](https://github.com/variant-inc/dx-hotfix)
The project can be deleted from SonarCloud and the tests can be repeated.

- Test Case 1 [Control (current behavior]
  - Steps 
    - commit and push a master branch of a project that did not have a successful analysis in sonarcloud
    - https://github.com/variant-inc/dx-demo-cron/actions/runs/2665925707
  - Result
    - The exception is thrown
    - https://github.com/variant-inc/dx-demo-cron/runs/7328282325?check_suite_focus=true#step:5:169   

- Test Case 2 [Apply the fix]
  - Steps
    - point to the test actions-python branch `f/hotfix-skip-sonar`
  - Result
    - The skip_sonar_run.ps1 executes successfully
    - https://github.com/variant-inc/dx-demo-cron/runs/7329378147?check_suite_focus=true#step:5:158

- Test Case 3 [Prove the premise]
  - Steps
    - revert the actions-python version in the test project back to `v1`
  - Results
    - The error from Test Case 1 is not longer present because a commit exists
    - https://github.com/variant-inc/dx-demo-cron/runs/7329433022?check_suite_focus=true#step:5:177
   
- [x] Sanity Testing

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added documentation to test
