### PR TITLE
[CLOUD-1872] added logic to skip scan only if previous scan qualityGateStatus is OK

### DIFF
--- a/.github/linters/.powershell-psscriptanalyzer.psd1
+++ b/.github/linters/.powershell-psscriptanalyzer.psd1
@@ -1,5 +1,6 @@
 @{
     ExcludeRules = @(
         'PSAvoidUsingInvokeExpression'
+        ,'PSUseOutputTypeCorrectly'
     )
 }


### PR DESCRIPTION
# Description

Allows skipping scan only if the previous scan status was OK

Fixes [CLOUD-1872](https://drivevariant.atlassian.net/browse/CLOUD-1872)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

[actions-python test branch](https://github.com/variant-inc/actions-python/tree/t/sonarcommitstatus)
[test python repo](https://github.com/variant-inc/dx-demo-cron)

Prereq:
- The test repo must be added to the [All Code quality gate](https://sonarcloud.io/organizations/variant/quality_gates/show/66371)

Test Case 1 [Control: Project exists and code coverage is good]:
- Steps
  - set `uses: variant-inc/actions-python@t/sonarcommitstatus` for the Lazy actions steps in the test repo's workflow 
  - ensure the test repo has proper code coverage 
  - Update and push the master branch of a test repo 
- Result
  - workflow should succeed and sonar scan should have run.

Test Case 2 [Control: rerun a workflow that had successful sonar scan]:
- Steps
  - rerun the workflow from Test Case 1
- Result
  - workflow should succeed and sonar scan should have been skipped Search for `Skip sonar run`.

Test Case 3 [Failed sonar scan should not skip on rerun]:
- Steps
  - set `uses: variant-inc/actions-python@t/sonarcommitstatus` for the Lazy actions steps in the test repo's workflow 
  - ensure the test repo will fail code coverage
  - Update and push the master branch of a test repo 
  - The workflow should fail due to Sonar Quality Gate
  - Rerun the workflow
- Result
  - workflow should fail due to Sonar Quality Gate. Sonar scan will not have been skipped.

- [x] Sanity Testing

## Checklist

- [x] My code follows the style guidelines of this project
- [x]  I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added documentation to test
