### PR TITLE
Allow overriding sonar wait flag by using a key in actions-secrets-v2 secret

### DIFF
--- a/sonar-setup/action.yml
+++ b/sonar-setup/action.yml
@@ -42,7 +42,8 @@ runs:
             wait_flag=$SONAR_OVERRIDE_WAIT_FLAG
         else
             if [ "$GitVersion_PreReleaseLabel" == "" ]; then
-                echo "Setting wait_flag to true because GitVersion_PreReleaseLabel is empty"
+                echo "Setting wait_flag to \
+                true because GitVersion_PreReleaseLabel is empty"
                 wait_flag="true"
             fi
         fi

--- a/sonar-setup/action.yml
+++ b/sonar-setup/action.yml
@@ -36,11 +36,24 @@ runs:
       id: flags
       shell: bash
       run: |
-        wait_flag="false"
-        if [ "$GitVersion_PreReleaseLabel" == "" ]; then
-          # wait_flag="true"
-          echo "$wait_flag"
+        echo "secret=$SONAR_OVERRIDE_WAIT_FLAG"
+        echo $SONAR_OVERRIDE_WAIT_FLAG
+
+        override_sonar_wait_flag=$SONAR_OVERRIDE_WAIT_FLAG
+        if [ -n "$override_sonar_wait_flag" ]; then
+            wait_flag=$override_sonar_wait_flag
+            echo "using value from secrets"
+        else
+            wait_flag="false"
+            echo "Not using value from secrets"
+            if [  "$GitVersion_PreReleaseLabel" == "" ]; then
+                echo "using empty git pre-release label"
+                wait_flag="true"
+            fi
+             echo "using non empty git pre-release label"
+            echo "$wait_flag"
         fi
+
         echo "wait_flag=$wait_flag" >> $GITHUB_OUTPUT
         echo "wait_flag=$wait_flag"
 

--- a/sonar-setup/action.yml
+++ b/sonar-setup/action.yml
@@ -36,23 +36,17 @@ runs:
       id: flags
       shell: bash
       run: |
-        echo "secret=$SONAR_OVERRIDE_WAIT_FLAG"
-        echo $SONAR_OVERRIDE_WAIT_FLAG
-
-        override_sonar_wait_flag=$SONAR_OVERRIDE_WAIT_FLAG
-        if [ -n "$override_sonar_wait_flag" ]; then
-            wait_flag=$override_sonar_wait_flag
-            echo "using value from secrets"
+        wait_flag="false"
+        if [ -n "$SONAR_OVERRIDE_WAIT_FLAG" ]; then
+            echo "Overriding wait_flag to $SONAR_OVERRIDE_WAIT_FLAG"
+            wait_flag=$SONAR_OVERRIDE_WAIT_FLAG
         else
-            wait_flag="false"
-            echo "Not using value from secrets"
-            if [  "$GitVersion_PreReleaseLabel" == "" ]; then
-                echo "using empty git pre-release label"
+            if [ "$GitVersion_PreReleaseLabel" == "" ]; then
+                echo "Setting wait_flag to true because GitVersion_PreReleaseLabel is empty"
                 wait_flag="true"
             fi
-             echo "using non empty git pre-release label"
-            echo "$wait_flag"
         fi
+        echo "Sonar Wait Flag is $wait_flag"
 
         echo "wait_flag=$wait_flag" >> $GITHUB_OUTPUT
         echo "wait_flag=$wait_flag"


### PR DESCRIPTION
# Description
Call the overridden variable to be override_sonar_wait_flag
- If override_sonar_wait_flag is set to anything, use that instead of wait_flag in sonar_check action.
- if override_sonar_wait_flag is empty or non existent, use the wait_flag in sonar_check action.

This will change the wait_flag value controlling if the actions workflow will fail when sonar analysis fails. 

wait_flag = TRUE  should fail in GitHub when the sonar scan coverage is too low
wait_flag = FALSE will allow GitHub to succeed although sonar fails (always work) 

Fixes [#8](https://usxpress.atlassian.net/browse/CLOUD-8)

## Type of change

 
- [x] New feature (non-breaking change which adds functionality)


## How Has This Been Tested?

### Ran through scenarios below 

#### With failure - Value in Secret is true

https://github.com/variant-inc/demo-python-flask-variant-api/actions/runs/10637213914/job/29490639943

<img width="1178" alt="Pasted Graphic 2" src="https://github.com/user-attachments/assets/adbe4384-4b83-4f69-b82e-aefb947182d0">
<img width="1388" alt="Pasted Graphic 11" src="https://github.com/user-attachments/assets/0c00c76a-d4e2-457e-bcfe-41031c8990e9">


#### No fail - Value in Secret is false

https://github.com/variant-inc/demo-python-flask-variant-api/actions/runs/10637154624/job/29490457686

<img width="1178" alt="Pasted Graphic 3" src="https://github.com/user-attachments/assets/6a164a68-9fb3-48f7-81ae-21a5e88997e1">
<img width="1388" alt="Pasted Graphic 10" src="https://github.com/user-attachments/assets/8f95c3a1-616d-48ee-b9c2-c7725c3a521a">


#### No value in secret - With Empty Git pre release label uses true

https://github.com/variant-inc/demo-python-flask-variant-api/actions/runs/10637267764

<img width="1334" alt="Pasted Graphic 8" src="https://github.com/user-attachments/assets/a8ace211-249f-48f4-aae1-3aedf9034ca3">
<img width="1388" alt="Pasted Graphic 12" src="https://github.com/user-attachments/assets/4cb4fdbc-c582-44c9-8214-68bfa98bf17c">
 
#### No value in secret - Without empty git pre release label uses false

https://github.com/variant-inc/demo-python-flask-variant-api/actions/runs/10637416131/job/29491239594

<img width="1334" alt="Pasted Graphic 8" src="https://github.com/user-attachments/assets/a8ace211-249f-48f4-aae1-3aedf9034ca3">
<img width="331" alt="image" src="https://github.com/user-attachments/assets/4b1abaab-e0c9-4a41-8d9e-35113f26c607">

- [x] Sanity Testing

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added documentation to test
