### PR TITLE
ID-978 Export Protobufs to GitHub Releases

### DIFF
--- a/create-release-tag/README.md
+++ b/create-release-tag/README.md
@@ -20,6 +20,8 @@ permissions:
 ```yaml
 - name: Create Release Action
   uses: variant-inc/actions-collection/create-release-tag@v2
+  env:
+    RELEASE_FILES_GLOB: 'binaries/*' # Glob pattern for files to upload
   with:
     create_release: 'true'
 ```

--- a/create-release-tag/action.yml
+++ b/create-release-tag/action.yml
@@ -19,6 +19,8 @@ description: |
   ```yaml
   - name: Create Release Action
     uses: variant-inc/actions-collection/create-release-tag@v2
+    env:
+      RELEASE_FILES_GLOB: 'binaries/*' # Glob pattern for files to upload
     with:
       create_release: 'true'
   ```
@@ -44,3 +46,12 @@ runs:
         script: |
           const script = require('${{ github.action_path }}/release.js')
           await script({github, context})
+    - name: Upload binaries to release
+      uses: svenstaro/upload-release-action@v2
+      if: ${{ env.RELEASE_FILES_GLOB != '' && env.GitVersion_PreReleaseLabel == '' && inputs.create_release == 'true' }}
+      with:
+        repo_token: ${{ env.GITHUB_TOKEN }}
+        file: ${{ env.RELEASE_FILES_GLOB }}
+        tag: v${{ env.GitVersion_MajorMinorPatch }}
+        overwrite: true
+        file_glob: true


### PR DESCRIPTION
Adds functionality to upload binary files to a GitHub release.

- Introduces an optional `RELEASE_FILES_GLOB` environment variable to specify a glob pattern for files to include in the release.
- Leverages the `svenstaro/upload-release-action` to handle the upload process.
- The upload only occurs when a release is created, a file glob is specified, and the release is not a pre-release.

Fixes [#8](https://usxpress.atlassian.net/browse/CLOUD-8)

## Type of change

- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [ ] Sanity Testing

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added documentation to test